### PR TITLE
fix: fixed user page listing re-posts from other users of his own posts

### DIFF
--- a/src/repositories/hashtags.repositories.js
+++ b/src/repositories/hashtags.repositories.js
@@ -35,12 +35,15 @@ async function listHashtagPosts(hashtag) {
                       u.picture,
                       p.id AS "postId",
                       p.description,
-                      p.url
+                      p.url,
+					  NULL AS "shareId",
+					  NULL AS "shareUserId",
+					  NULL AS "shareUserName"	  
                     FROM posts AS p
                     JOIN users AS u ON u.id=p."userId"
                     JOIN "postsHashtags" AS ph ON ph."postId" = p.id
                     JOIN hashtags AS h ON h.id = ph."hashtagId"
-					          WHERE p."deletedAt" IS NULL AND h.name = $1
+					WHERE p."deletedAt" IS NULL AND h.name = $1
                     ORDER BY p."createdAt" DESC
                     LIMIT 20;`,
 		[hashtag]

--- a/src/repositories/user.repositories.js
+++ b/src/repositories/user.repositories.js
@@ -51,7 +51,7 @@ async function listUserPosts(userId) {
           
           ) AS "feed"
         
-        WHERE feed."userId" = $1 OR feed."shareUserId"=$1
+        WHERE (feed."userId"=$1 AND feed."shareId" IS NULL) OR feed."shareUserId"=$1
         ORDER BY feed."createdAt" DESC;`,
 		[ userId ]
 	);


### PR DESCRIPTION
What has been fixed:
- Now user page only lists the Original User posts and posts from other users that the User has re-posted